### PR TITLE
gs-99 - adding page title component and story

### DIFF
--- a/02-molecules/page-title/PageTitle.component.js
+++ b/02-molecules/page-title/PageTitle.component.js
@@ -4,8 +4,8 @@ import Header from '../../01-atoms/text/Heading.component';
 import withModifiers from '../../_utils/withModifiers';
 
 const PageTitle = ({ PageTitleModifiers, heading }) => (
-  <div className={withModifiers('page-title page-title__wrapper')(PageTitleModifiers)}>
-    <Header level="1" baseClass="page-title__heading">
+  <div className={withModifiers('page-title__wrapper')(PageTitleModifiers)}>
+    <Header level="1" baseClass="page-title">
       {heading}
     </Header>
   </div>

--- a/02-molecules/page-title/PageTitle.component.js
+++ b/02-molecules/page-title/PageTitle.component.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import Header from '../../01-atoms/text/Heading.component';
 import withModifiers from '../../_utils/withModifiers';
 
-const PageTitle = ({ PageTitleModifiers, heading }) => (
-  <div className={withModifiers('page-title__wrapper')(PageTitleModifiers)}>
+const PageTitle = ({ Modifiers, heading }) => (
+  <div className={withModifiers('page-title__wrapper')(Modifiers)}>
     <Header level="1" baseClass="page-title">
       {heading}
     </Header>
@@ -12,7 +12,7 @@ const PageTitle = ({ PageTitleModifiers, heading }) => (
 );
 
 PageTitle.propTypes = {
-  PageTitleModifiers: PropTypes.arrayOf(PropTypes.string),
+  Modifiers: PropTypes.arrayOf(PropTypes.string),
   heading: PropTypes.string.isRequired,
 };
 

--- a/02-molecules/page-title/PageTitle.component.js
+++ b/02-molecules/page-title/PageTitle.component.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Header from '../../01-atoms/text/Heading.component';
+import withModifiers from '../../_utils/withModifiers';
+
+const PageTitle = ({ PageTitleModifiers, heading }) => (
+  <div className={withModifiers('page-title page-title__wrapper')(PageTitleModifiers)}>
+    <Header level="1" baseClass="page-title__heading">
+      {heading}
+    </Header>
+  </div>
+);
+
+PageTitle.propTypes = {
+  PageTitleModifiers: PropTypes.arrayOf(PropTypes.string),
+  heading: PropTypes.string.isRequired,
+};
+
+export default PageTitle;

--- a/02-molecules/page-title/PageTitle.stories.js
+++ b/02-molecules/page-title/PageTitle.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import PageTitle from './PageTitle.component';
+
+/**
+ * Storybook Definition.
+ */
+export default { title: 'Molecules/Page Title' };
+
+export const pageTitle = () => (
+  <PageTitle heading="This is a PageTitle" />
+);

--- a/02-molecules/page-title/PageTitle.stories.js
+++ b/02-molecules/page-title/PageTitle.stories.js
@@ -8,5 +8,5 @@ import PageTitle from './PageTitle.component';
 export default { title: 'Molecules/Page Title' };
 
 export const pageTitle = () => (
-  <PageTitle heading="This is a PageTitle" />
+  <PageTitle heading="This is the page title" />
 );


### PR DESCRIPTION
## to test
- [ ] pull down branch
- [ ] view page title component: http://localhost:6006/?path=/story/molecules-page-title--page-title
- [ ] compare it to the twig version here and see that the markup is the same: https://dev-westernuni.pantheonsite.io/storybook/?path=/story/molecules-page-title--page-title

![Screenshot-2020-04-30-14-13-28-1338x1014](https://user-images.githubusercontent.com/366413/80749931-d6454400-8aec-11ea-93cd-791a4b687e48.png)


