### PR TITLE
GS-92: Image Component 

### DIFF
--- a/01-atoms/image/Figure.component.js
+++ b/01-atoms/image/Figure.component.js
@@ -4,9 +4,9 @@ import { imageTypeProps } from './Image.component';
 import ResponsiveImage from './ResponsiveImage.component';
 import withModifiers from '../../_utils/withModifiers';
 
-const Figure = ({ modifiers, link, caption, outputImage, sources, src, srcset, sizes, alt, title }) => 
+const Figure = ({ modifiers, url, caption, outputImage, sources, src, srcset, sizes, alt, title }) => 
   <figure className={withModifiers('figure')(modifiers)}>
-    <ConditionalLink link={link} >
+    <ConditionalLink url={url} >
       <ResponsiveImage 
         outputImage={outputImage}
         sources={sources}
@@ -33,15 +33,10 @@ Figure.propTypes = {
   ...imageTypeProps
 };
 
-const ConditionalLink = ({ link, modifiers, children }) => 
+const ConditionalLink = ({ url, children }) => 
   <>
-    { link ? (
-      <a 
-        className='link'
-        href={link}
-      >
-        {children}
-      </a>
+    { url ? (
+      <a className='link' href={url}>{children}</a>
     ) : (
        children 
     )}

--- a/01-atoms/image/Figure.component.js
+++ b/01-atoms/image/Figure.component.js
@@ -1,16 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { imagePropType } from './Image.component';
+import { imageTypeProps } from './Image.component';
 import ResponsiveImage from './ResponsiveImage.component';
 import withModifiers from '../../_utils/withModifiers';
 
-const Figure = ({ modifiers, link, caption, outputImage, sources, image }) => 
+const Figure = ({ modifiers, link, caption, outputImage, sources, src, srcset, sizes, alt, title }) => 
   <figure className={withModifiers('figure')(modifiers)}>
     <ConditionalLink link={link} >
       <ResponsiveImage 
         outputImage={outputImage}
         sources={sources}
-        image={image}
+        src={src}
+        srcSet={srcset}
+        sizes={sizes}
+        alt={alt}
+        title={title}
       />
     </ConditionalLink>
     <figcaption className='figure__caption'>
@@ -26,7 +30,7 @@ Figure.propTypes = {
     media: PropTypes.string,
     source: PropTypes.string.isRequired
   }),
-  image: imagePropType
+  ...imageTypeProps
 };
 
 const ConditionalLink = ({ link, modifiers, children }) => 

--- a/01-atoms/image/Figure.component.js
+++ b/01-atoms/image/Figure.component.js
@@ -6,20 +6,16 @@ import withModifiers from '../../_utils/withModifiers';
 
 const Figure = ({ modifiers, link, caption, outputImage, sources, image }) => 
   <figure className={withModifiers('figure')(modifiers)}>
-    <ConditionalLink 
-      link={link} 
-      modifiers={modifiers}
-    >
+    <ConditionalLink link={link} >
       <ResponsiveImage 
         outputImage={outputImage}
         sources={sources}
         image={image}
       />
     </ConditionalLink>
-    <figcaption className={withModifiers('caption')(modifiers)}>
+    <figcaption className='figure__caption'>
       { caption }
     </figcaption>
-    
   </figure>;
 
 Figure.propTypes = {
@@ -37,7 +33,7 @@ const ConditionalLink = ({ link, modifiers, children }) =>
   <>
     { link ? (
       <a 
-        className={withModifiers('link')(modifiers)} 
+        className='link'
         href={link}
       >
         {children}

--- a/01-atoms/image/Figure.component.js
+++ b/01-atoms/image/Figure.component.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { imagePropType } from './Image.component';
+import ResponsiveImage from './ResponsiveImage.component';
+import withModifiers from '../../_utils/withModifiers';
+
+const Figure = ({ modifiers, link, caption, outputImage, sources, image }) => 
+  <figure className={withModifiers('figure')(modifiers)}>
+    <ConditionalLink 
+      link={link} 
+      modifiers={modifiers}
+    >
+      <ResponsiveImage 
+        outputImage={outputImage}
+        sources={sources}
+        image={image}
+      />
+    </ConditionalLink>
+    <figcaption className={withModifiers('caption')(modifiers)}>
+      { caption }
+    </figcaption>
+    
+  </figure>;
+
+Figure.propTypes = {
+  modifiers: PropTypes.arrayOf(PropTypes.string),
+  caption: PropTypes.string,
+  outputImage: PropTypes.bool,
+  sources: PropTypes.arrayOf({
+    media: PropTypes.string,
+    source: PropTypes.string.isRequired
+  }),
+  image: imagePropType
+};
+
+const ConditionalLink = ({ link, modifiers, children }) => 
+  <>
+    { link ? (
+      <a 
+        className={withModifiers('link')(modifiers)} 
+        href={link}
+      >
+        {children}
+      </a>
+    ) : (
+       children 
+    )}
+  </>;
+
+export default Figure;

--- a/01-atoms/image/Image.component.js
+++ b/01-atoms/image/Image.component.js
@@ -2,26 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import withModifiers from '../../_utils/withModifiers';
 
-const Image = ({ modifiers, imageSrcset, imageSizes, imageSrc, imageAlt, imageTitle }) => {
+const Image = ({ modifiers, src, srcset, sizes, alt, title }) => {
   return (
     <img
-    className={withModifiers('img')(modifiers)}
-      srcSet={imageSrcset}
-      sizes={imageSizes}
-      src={imageSrc}
-      alt={imageAlt}
-      title={imageTitle}
+      className={withModifiers('img')(modifiers)}
+      src={src}
+      srcSet={srcset}
+      sizes={sizes}
+      alt={alt}
+      title={title}
     />
   );
 }
 
-Image.propTypes = {
+export const imagePropType = PropTypes.shape({
   modifiers: PropTypes.arrayOf(PropTypes.string),
-  imageSrcset: PropTypes.string,
-  imageSizes: PropTypes.string,
-  imageSrc: PropTypes.string,
-  imageAlt: PropTypes.string,
-  imageTitle: PropTypes.string
-};
+  src: PropTypes.string,
+  srcset: PropTypes.string,
+  sizes: PropTypes.string,
+  alt: PropTypes.string,
+  title: PropTypes.string
+});
+
+Image.propTypes = imagePropType;
 
 export default Image;

--- a/01-atoms/image/Image.component.js
+++ b/01-atoms/image/Image.component.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import withModifiers from '../../_utils/withModifiers';
+
+const Image = ({ modifiers, imageSrcset, imageSizes, imageSrc, imageAlt, imageTitle }) => {
+  return (
+    <img
+    className={withModifiers('img')(modifiers)}
+      srcSet={imageSrcset}
+      sizes={imageSizes}
+      src={imageSrc}
+      alt={imageAlt}
+      title={imageTitle}
+    />
+  );
+}
+
+Image.propTypes = {
+  modifiers: PropTypes.arrayOf(PropTypes.string),
+  imageSrcset: PropTypes.string,
+  imageSizes: PropTypes.string,
+  imageSrc: PropTypes.string,
+  imageAlt: PropTypes.string,
+  imageTitle: PropTypes.string
+};
+
+export default Image;

--- a/01-atoms/image/Image.component.js
+++ b/01-atoms/image/Image.component.js
@@ -15,7 +15,7 @@ const Image = ({ modifiers, src, srcset, sizes, alt, title }) => {
   );
 }
 
-export const imagePropType = PropTypes.shape({
+export const imageTypeProps = PropTypes.shape({
   modifiers: PropTypes.arrayOf(PropTypes.string),
   src: PropTypes.string,
   srcset: PropTypes.string,
@@ -24,6 +24,6 @@ export const imagePropType = PropTypes.shape({
   title: PropTypes.string
 });
 
-Image.propTypes = imagePropType;
+Image.propTypes = imageTypeProps;
 
 export default Image;

--- a/01-atoms/image/Picture.component.js
+++ b/01-atoms/image/Picture.component.js
@@ -1,20 +1,18 @@
 import React from 'react';
 import PropTypes, { any } from 'prop-types';
-import Image from './Image.component';
+import Image, { imagePropType } from './Image.component';
 import withModifiers from '../../_utils/withModifiers';
 
-const Picture = ({ modifiers, sources = [], imageSrcset, imageSizes, imageSrc, imageAlt, imageTitle }) => {
+const Picture = ({ modifiers, sources = [], image: { src, srcset, sizes, alt, title } }) => {
   return (
-    <picture
-      className={withModifiers('picture')(modifiers)}
-    >
+    <picture className={withModifiers('picture')(modifiers)}>
       { sources.map( source => <source {...source} /> ) }
       <Image
-        imageSrcset={imageSrcset}
-        imageSizes={imageSizes}
-        imageSrc={imageSrc}
-        imageAlt={imageAlt}
-        imageTitle={imageTitle}
+        src={src}
+        srcSet={srcset}
+        sizes={sizes}
+        alt={alt}
+        title={title}
       />
     </picture>
   );
@@ -22,15 +20,11 @@ const Picture = ({ modifiers, sources = [], imageSrcset, imageSizes, imageSrc, i
 
 Picture.propTypes = {
   modifiers: PropTypes.arrayOf(PropTypes.string),
+  image: imagePropType,
   sources: PropTypes.arrayOf({
     media: PropTypes.string,
     source: PropTypes.string.isRequired
-  }),
-  imageSrcset: PropTypes.string,
-  imageSizes: PropTypes.string,
-  imageSrc: PropTypes.string,
-  imageAlt: PropTypes.string,
-  imageTitle: PropTypes.string
+  })
 };
 
 export default Picture;

--- a/01-atoms/image/Picture.component.js
+++ b/01-atoms/image/Picture.component.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes, { any } from 'prop-types';
-import Image, { imagePropType } from './Image.component';
+import Image, { imageTypeProps } from './Image.component';
 import withModifiers from '../../_utils/withModifiers';
 
-const Picture = ({ modifiers, sources = [], image: { src, srcset, sizes, alt, title } }) => {
+const Picture = ({ modifiers, sources = [], src, srcset, sizes, alt, title }) => {
   return (
     <picture className={withModifiers('picture')(modifiers)}>
       { sources.map( source => <source {...source} /> ) }
@@ -20,11 +20,11 @@ const Picture = ({ modifiers, sources = [], image: { src, srcset, sizes, alt, ti
 
 Picture.propTypes = {
   modifiers: PropTypes.arrayOf(PropTypes.string),
-  image: imagePropType,
   sources: PropTypes.arrayOf({
     media: PropTypes.string,
     source: PropTypes.string.isRequired
-  })
+  }),
+  ...imageTypeProps
 };
 
 export default Picture;

--- a/01-atoms/image/Picture.component.js
+++ b/01-atoms/image/Picture.component.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes, { any } from 'prop-types';
+import Image from './Image.component';
+import withModifiers from '../../_utils/withModifiers';
+
+const Picture = ({ modifiers, sources = [], imageSrcset, imageSizes, imageSrc, imageAlt, imageTitle }) => {
+  return (
+    <picture
+      className={withModifiers('picture')(modifiers)}
+    >
+      { sources.map( source => <source {...source} /> ) }
+      <Image
+        imageSrcset={imageSrcset}
+        imageSizes={imageSizes}
+        imageSrc={imageSrc}
+        imageAlt={imageAlt}
+        imageTitle={imageTitle}
+      />
+    </picture>
+  );
+}
+
+Picture.propTypes = {
+  modifiers: PropTypes.arrayOf(PropTypes.string),
+  sources: PropTypes.arrayOf({
+    media: PropTypes.string,
+    source: PropTypes.string.isRequired
+  }),
+  imageSrcset: PropTypes.string,
+  imageSizes: PropTypes.string,
+  imageSrc: PropTypes.string,
+  imageAlt: PropTypes.string,
+  imageTitle: PropTypes.string
+};
+
+export default Picture;

--- a/01-atoms/image/ResponsiveImage.component.js
+++ b/01-atoms/image/ResponsiveImage.component.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Image, { imagePropType } from './Image.component';
+import Image, { imageTypeProps } from './Image.component';
 import withModifiers from '../../_utils/withModifiers';
 
-const ResponsiveImage = ({ outputImage, modifiers, sources = [], image: { src, srcset, sizes, alt, title } }) => 
+const ResponsiveImage = ({ outputImage, modifiers, sources = [], src, srcset, sizes, alt, title }) => 
   <>
     { outputImage ? (
       <Image
@@ -35,7 +35,7 @@ ResponsiveImage.propTypes = {
     media: PropTypes.string,
     source: PropTypes.string.isRequired
   }),
-  image: imagePropType
+  ...imageTypeProps
 };
 
 export default ResponsiveImage;

--- a/01-atoms/image/ResponsiveImage.component.js
+++ b/01-atoms/image/ResponsiveImage.component.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Image, { imagePropType } from './Image.component';
+import withModifiers from '../../_utils/withModifiers';
+
+const ResponsiveImage = ({ outputImage, modifiers, sources = [], image: { src, srcset, sizes, alt, title } }) => 
+  <>
+    { outputImage ? (
+      <Image
+        modifiers={modifiers}
+        src={src}
+        srcSet={srcset}
+        sizes={sizes}
+        alt={alt}
+        title={title}
+      />
+    ) : (
+      <picture className={withModifiers('picture')(modifiers)}>
+        { sources.map( source => <source {...source} /> ) }
+        <Image
+          src={src}
+          srcSet={srcset}
+          sizes={sizes}
+          alt={alt}
+          title={title}
+        />
+      </picture>
+    )}
+  </>;
+
+ResponsiveImage.propTypes = {
+  outputImage: PropTypes.bool,
+  modifiers: PropTypes.arrayOf(PropTypes.string),
+  sources: PropTypes.arrayOf({
+    media: PropTypes.string,
+    source: PropTypes.string.isRequired
+  }),
+  image: imagePropType
+};
+
+export default ResponsiveImage;

--- a/01-atoms/image/figure.stories.js
+++ b/01-atoms/image/figure.stories.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Figure from './Figure.component';
+
+/**
+ * Storybook Definition.
+ */
+export default { title: 'Atoms/Image' };
+
+export const figure = () => (
+  <Figure
+    outputImage={true}
+    caption='This is an image caption.'
+    link='#'
+    image={{
+      alt: 'Random Image from Picsum',
+      src: 'https://picsum.photos/300/400.jpg'
+    }}
+  />
+)

--- a/01-atoms/image/figure.stories.js
+++ b/01-atoms/image/figure.stories.js
@@ -11,9 +11,7 @@ export const figure = () => (
     outputImage={true}
     caption='This is an image caption.'
     link='#'
-    image={{
-      alt: 'Random Image from Picsum',
-      src: 'https://picsum.photos/300/400.jpg'
-    }}
+    alt='Random Image from Picsum'
+    src='https://picsum.photos/300/400.jpg'
   />
 )

--- a/01-atoms/image/figure.stories.js
+++ b/01-atoms/image/figure.stories.js
@@ -10,8 +10,8 @@ export const figure = () => (
   <Figure
     outputImage={true}
     caption='This is an image caption.'
-    link='#'
+    url='#'
     alt='Random Image from Picsum'
-    src='https://picsum.photos/300/400.jpg'
+    src='https://placeimg.com/1200/200/tech'
   />
 )

--- a/01-atoms/image/image.stories.js
+++ b/01-atoms/image/image.stories.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import Image from './Image.component';
+
+/**
+ * Storybook Definition.
+ */
+export default { title: 'Atoms/Image' };
+
+export const plain = () => (
+  <Image
+    imageAlt='Random Image from Picsum'
+    imageSrc='https://picsum.photos/300/400.jpg'
+  />
+)
+
+export const srcSet = () => (
+  <Image
+    imageAlt='Random Image from Picsum using srcset'
+    imageSrcset='https://picsum.photos/400/300 400w, https://picsum.photos/800/700 800w'
+    imageSizes='(max-width:600px) 400px, 800px'
+    imageSrc='https://picsum.photos/400/300'
+  />
+)

--- a/01-atoms/image/image.stories.js
+++ b/01-atoms/image/image.stories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import Image from './Image.component';
 
 /**
@@ -9,16 +8,16 @@ export default { title: 'Atoms/Image' };
 
 export const plain = () => (
   <Image
-    imageAlt='Random Image from Picsum'
-    imageSrc='https://picsum.photos/300/400.jpg'
+    src='https://picsum.photos/300/400.jpg'
+    alt='Random Image from Picsum'
   />
 )
 
 export const srcSet = () => (
   <Image
-    imageAlt='Random Image from Picsum using srcset'
-    imageSrcset='https://picsum.photos/400/300 400w, https://picsum.photos/800/700 800w'
-    imageSizes='(max-width:600px) 400px, 800px'
-    imageSrc='https://picsum.photos/400/300'
+    src='https://picsum.photos/400/300'
+    alt='Random Image from Picsum using srcset'
+    srcset='https://picsum.photos/400/300 400w, https://picsum.photos/800/700 800w'
+    sizes='(max-width:600px) 400px, 800px'
   />
 )

--- a/01-atoms/image/image.stories.js
+++ b/01-atoms/image/image.stories.js
@@ -6,18 +6,18 @@ import Image from './Image.component';
  */
 export default { title: 'Atoms/Image' };
 
-export const plain = () => (
+export const image = () => (
   <Image
     src='https://picsum.photos/300/400.jpg'
     alt='Random Image from Picsum'
   />
 )
 
-export const srcSet = () => (
+export const imageSrcSet = () => (
   <Image
-    src='https://picsum.photos/400/300'
-    alt='Random Image from Picsum using srcset'
-    srcset='https://picsum.photos/400/300 400w, https://picsum.photos/800/700 800w'
-    sizes='(max-width:600px) 400px, 800px'
+    src='https://placeimg.com/320/180/any'
+    alt='A 16 by 9 image'
+    srcset='https://placeimg.com/320/180/any 320w, https://placeimg.com/480/270/any 480w, https://placeimg.com/640/360/any 640w, https://placeimg.com/800/450/any 800w, https://placeimg.com/960/540/any 960w, https://placeimg.com/1120/630/any 1120w, https://placeimg.com/1280/720/any 1280w, https://placeimg.com/1440/810/any 1440w, https://placeimg.com/1600/900/any 1600w, https://placeimg.com/1760/990/any 1760w, https://placeimg.com/1920/1080/any 1920w, https://placeimg.com/2080/1170/any 2080w, https://placeimg.com/2240/1260/any 2240w'
+    sizes='100vw'
   />
 )

--- a/01-atoms/image/picture.stories.js
+++ b/01-atoms/image/picture.stories.js
@@ -18,7 +18,9 @@ export const picture = () => (
         'source': 'https://picsum.photos/300/400.jpg'
       }
     ]}
-    imageAlt='Random Image from Picsum'
-    imageSrc='https://picsum.photos/300/400.jpg'
+    image = {{
+      alt: 'Random Image from Picsum',
+      src: 'https://picsum.photos/300/400.jpg'
+    }}
   />
 )

--- a/01-atoms/image/picture.stories.js
+++ b/01-atoms/image/picture.stories.js
@@ -18,9 +18,7 @@ export const picture = () => (
         'source': 'https://picsum.photos/300/400.jpg'
       }
     ]}
-    image = {{
-      alt: 'Random Image from Picsum',
-      src: 'https://picsum.photos/300/400.jpg'
-    }}
+    alt='Random Image from Picsum'
+    src='https://picsum.photos/300/400.jpg'
   />
 )

--- a/01-atoms/image/picture.stories.js
+++ b/01-atoms/image/picture.stories.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Picture from './Picture.component';
+
+/**
+ * Storybook Definition.
+ */
+export default { title: 'Atoms/Image' };
+
+export const picture = () => (
+  <Picture
+    sources={[
+      {
+        'media': '(min-width: 650px)', 
+        'source': 'https://picsum.photos/400/525.jpg'
+      },
+      {
+        'media': '(min-width: 465px)', 
+        'source': 'https://picsum.photos/300/400.jpg'
+      }
+    ]}
+    imageAlt='Random Image from Picsum'
+    imageSrc='https://picsum.photos/300/400.jpg'
+  />
+)

--- a/01-atoms/image/responsiveimage.stories.js
+++ b/01-atoms/image/responsiveimage.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import ResponsiveImage from './ResponsiveImage.component';
+
+/**
+ * Storybook Definition.
+ */
+export default { title: 'Atoms/Image' };
+
+export const responsive = () => (
+  <ResponsiveImage
+    outputImage={true}
+    sources={[
+      {
+        'media': '(min-width: 650px)', 
+        'source': 'https://picsum.photos/400/525.jpg'
+      },
+      {
+        'media': '(min-width: 465px)', 
+        'source': 'https://picsum.photos/300/400.jpg'
+      }
+    ]}
+    image={{
+      alt: 'Random Image from Picsum',
+      src: 'https://picsum.photos/300/400.jpg'
+    }}
+  />
+)

--- a/01-atoms/image/responsiveimage.stories.js
+++ b/01-atoms/image/responsiveimage.stories.js
@@ -8,7 +8,7 @@ export default { title: 'Atoms/Image' };
 
 export const responsive = () => (
   <ResponsiveImage
-    outputImage={true}
+    outputImage={false}
     sources={[
       {
         'media': '(min-width: 650px)', 
@@ -19,9 +19,7 @@ export const responsive = () => (
         'source': 'https://picsum.photos/300/400.jpg'
       }
     ]}
-    image={{
-      alt: 'Random Image from Picsum',
-      src: 'https://picsum.photos/300/400.jpg'
-    }}
+    alt='Random Image from Picsum'
+    src='https://picsum.photos/300/400.jpg'
   />
 )


### PR DESCRIPTION
## Description of Work
- Adds the Image, ResponsiveImage, Figure, and Picture components to mirror the twig components.
- Creates at least 1 story for each new component.

## Possible items to do
- ~The HTML comment for IE9 capability of <figure> elements is not included in this work. There are several ways to approach this in react, but simply adding an HTML comment to the JSX is not an option. I am looking for feedback. Do we want to include this fallback at this time? Or not worth the investment for this demo? [See twig template](https://github.com/emulsify-ds/emulsify-drupal/blob/develop/components/01-atoms/images/image/_picture.twig)~

## Test Plan
- [x] Pull down the branch and start storybook `yarn storybook` for the parent repo.
- [x] Image: Compare React components to twig:
  - React: http://localhost:6006/?path=/story/atoms-image--image-src-set
  - Twig: https://dev-westernuni.pantheonsite.io/storybook/?path=/story/atoms-images--images
- [x] Figure: Compare React components to twig:
  - React: http://localhost:6006/?path=/story/atoms-image--figure
  - Twig: https://dev-westernuni.pantheonsite.io/storybook/?path=/story/atoms-images--figures
- [x] Responsive Image: This react component is used inside the Figure component. Compare the component against the source twig to ensure all of the right pieces are in order.
  - Twig: https://github.com/emulsify-ds/emulsify-drupal/blob/develop/components/01-atoms/images/image/responsive-image.twig
- [x] Picture: This React component is not shown in the twig storybook. It is one of the display modes of a responsive image. Compare the component against the source twig to ensure all of the right pieces are in order:
  - Twig: https://github.com/emulsify-ds/emulsify-drupal/blob/develop/components/01-atoms/images/image/_picture.twig