### PR TITLE
1. GS-92: Image property refactor

### DIFF
--- a/01-atoms/image/Figure.component.js
+++ b/01-atoms/image/Figure.component.js
@@ -4,17 +4,19 @@ import { imageTypeProps } from './Image.component';
 import ResponsiveImage from './ResponsiveImage.component';
 import withModifiers from '../../_utils/withModifiers';
 
-const Figure = ({ modifiers, url, caption, outputImage, sources, src, srcset, sizes, alt, title }) => 
+const Figure = ({ modifiers, url, caption, outputImage, sources, image }) =>
   <figure className={withModifiers('figure')(modifiers)}>
     <ConditionalLink url={url} >
-      <ResponsiveImage 
+      <ResponsiveImage
         outputImage={outputImage}
         sources={sources}
-        src={src}
-        srcSet={srcset}
-        sizes={sizes}
-        alt={alt}
-        title={title}
+        image={{
+          src: image.src,
+          srcSet: image.srcset,
+          sizes: image.sizes,
+          alt: image.alt,
+          title: image.title,
+        }}
       />
     </ConditionalLink>
     <figcaption className='figure__caption'>
@@ -24,21 +26,21 @@ const Figure = ({ modifiers, url, caption, outputImage, sources, src, srcset, si
 
 Figure.propTypes = {
   modifiers: PropTypes.arrayOf(PropTypes.string),
+  image: imageTypeProps,
   caption: PropTypes.string,
   outputImage: PropTypes.bool,
   sources: PropTypes.arrayOf({
     media: PropTypes.string,
     source: PropTypes.string.isRequired
   }),
-  ...imageTypeProps
 };
 
-const ConditionalLink = ({ url, children }) => 
+const ConditionalLink = ({ url, children }) =>
   <>
     { url ? (
       <a className='link' href={url}>{children}</a>
     ) : (
-       children 
+       children
     )}
   </>;
 

--- a/01-atoms/image/Figure.component.js
+++ b/01-atoms/image/Figure.component.js
@@ -10,13 +10,7 @@ const Figure = ({ modifiers, url, caption, outputImage, sources, image }) =>
       <ResponsiveImage
         outputImage={outputImage}
         sources={sources}
-        image={{
-          src: image.src,
-          srcSet: image.srcset,
-          sizes: image.sizes,
-          alt: image.alt,
-          title: image.title,
-        }}
+        image={image}
       />
     </ConditionalLink>
     <figcaption className='figure__caption'>

--- a/01-atoms/image/Picture.component.js
+++ b/01-atoms/image/Picture.component.js
@@ -3,16 +3,16 @@ import PropTypes, { any } from 'prop-types';
 import Image, { imageTypeProps } from './Image.component';
 import withModifiers from '../../_utils/withModifiers';
 
-const Picture = ({ modifiers, sources = [], src, srcset, sizes, alt, title }) => {
+const Picture = ({ modifiers, sources = [], image }) => {
   return (
     <picture className={withModifiers('picture')(modifiers)}>
       { sources.map( source => <source {...source} /> ) }
       <Image
-        src={src}
-        srcSet={srcset}
-        sizes={sizes}
-        alt={alt}
-        title={title}
+        src={image.src}
+        srcSet={image.srcset}
+        sizes={image.sizes}
+        alt={image.alt}
+        title={image.title}
       />
     </picture>
   );
@@ -24,7 +24,7 @@ Picture.propTypes = {
     media: PropTypes.string,
     source: PropTypes.string.isRequired
   }),
-  ...imageTypeProps
+  image: imageTypeProps
 };
 
 export default Picture;

--- a/01-atoms/image/ResponsiveImage.component.js
+++ b/01-atoms/image/ResponsiveImage.component.js
@@ -3,26 +3,26 @@ import PropTypes from 'prop-types';
 import Image, { imageTypeProps } from './Image.component';
 import withModifiers from '../../_utils/withModifiers';
 
-const ResponsiveImage = ({ outputImage, modifiers, sources = [], src, srcset, sizes, alt, title }) => 
+const ResponsiveImage = ({ outputImage, modifiers, sources = [], image }) =>
   <>
     { outputImage ? (
       <Image
         modifiers={modifiers}
-        src={src}
-        srcSet={srcset}
-        sizes={sizes}
-        alt={alt}
-        title={title}
+        src={image.src}
+        srcSet={image.srcset}
+        sizes={image.sizes}
+        alt={image.alt}
+        title={image.title}
       />
     ) : (
       <picture className={withModifiers('picture')(modifiers)}>
         { sources.map( source => <source {...source} /> ) }
         <Image
-          src={src}
-          srcSet={srcset}
-          sizes={sizes}
-          alt={alt}
-          title={title}
+          src={image.src}
+          srcSet={image.srcset}
+          sizes={image.sizes}
+          alt={image.alt}
+          title={image.title}
         />
       </picture>
     )}
@@ -35,7 +35,7 @@ ResponsiveImage.propTypes = {
     media: PropTypes.string,
     source: PropTypes.string.isRequired
   }),
-  ...imageTypeProps
+  image: imageTypeProps
 };
 
 export default ResponsiveImage;

--- a/01-atoms/image/figure.stories.js
+++ b/01-atoms/image/figure.stories.js
@@ -11,7 +11,9 @@ export const figure = () => (
     outputImage={true}
     caption='This is an image caption.'
     url='#'
-    alt='Random Image from Picsum'
-    src='https://placeimg.com/1200/200/tech'
+    image={{
+      alt: 'Random Image from Picsum',
+      src: 'https://placeimg.com/1200/200/tech'
+    }}
   />
 )

--- a/01-atoms/image/picture.stories.js
+++ b/01-atoms/image/picture.stories.js
@@ -10,15 +10,17 @@ export const picture = () => (
   <Picture
     sources={[
       {
-        'media': '(min-width: 650px)', 
+        'media': '(min-width: 650px)',
         'source': 'https://picsum.photos/400/525.jpg'
       },
       {
-        'media': '(min-width: 465px)', 
+        'media': '(min-width: 465px)',
         'source': 'https://picsum.photos/300/400.jpg'
       }
     ]}
-    alt='Random Image from Picsum'
-    src='https://picsum.photos/300/400.jpg'
+    image={{
+      alt: 'Random Image from Picsum',
+      src: 'https://picsum.photos/300/400.jpg'
+    }}
   />
 )

--- a/01-atoms/image/responsiveimage.stories.js
+++ b/01-atoms/image/responsiveimage.stories.js
@@ -23,6 +23,5 @@ export const responsive = () => (
       alt: 'Random Image from Picsum',
       src: 'https://picsum.photos/300/400.jpg'
     }}
-    a
   />
 )

--- a/01-atoms/image/responsiveimage.stories.js
+++ b/01-atoms/image/responsiveimage.stories.js
@@ -11,15 +11,18 @@ export const responsive = () => (
     outputImage={false}
     sources={[
       {
-        'media': '(min-width: 650px)', 
+        'media': '(min-width: 650px)',
         'source': 'https://picsum.photos/400/525.jpg'
       },
       {
-        'media': '(min-width: 465px)', 
+        'media': '(min-width: 465px)',
         'source': 'https://picsum.photos/300/400.jpg'
       }
     ]}
-    alt='Random Image from Picsum'
-    src='https://picsum.photos/300/400.jpg'
+    image={{
+      alt: 'Random Image from Picsum',
+      src: 'https://picsum.photos/300/400.jpg'
+    }}
+    a
   />
 )


### PR DESCRIPTION
## Description of Work
Refactors images components to pass a single property with a prescriptive shape. That is:
```
const Picture = ({ modifiers, sources = [], src, scrset, sizes, alt, title })
```
has become
```
const Picture = ({ modifiers, sources = [], image })
```
## Test Plan
- [x] Start the storybook application from the project root `yarn storybook`.
- [x] Review all components in the `Atoms/Image` section and verify that an image is rendered. This is a non-function changeset, so nothing should have changed.
- [x] We do not have real test coverage on this component. So please take some time to review the code to make sure properties are pass around correctly in a new way. That is:
  - [x] Previously properties were passed to components as separate props `src, srcset, alt, title...` but now that is passed as a single prop `image`.
  - [ ] The usage of these properties has been updated to reflect the addition of this image object. So `src={src}` is now `src={image.src}`.
  - [ ] Proptypes were updated to use a single `image: ImagePropType` rather than spreading all of the image props `...ImagePropType`